### PR TITLE
Issue #8: 規範生成系 LAW_CHANGE フロー実装


### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,8 @@ POSTGRES_DB=postgres
 # サービス間認証（Service JWT）。全サービスで同一のシークレットを共有すること。
 SERVICE_JWT_SECRET=dev-service-jwt-secret-change-in-production
 
+# 規範生成系（立法）から監査ログ送信先（Issue #8）。未設定時は送信しない。
+# ROOT_SERVICE_URL=http://root:8080
+
 # 本番用（docker-compose.prod.yml 利用時は必須。カンマ区切りでホスト名を指定）
 # ALLOWED_HOSTS=example.com,api.example.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,7 @@ jobs:
 
       - name: Run pytest (root)
         run: docker run --rm -e DJANGO_SETTINGS_MODULE=root.settings app:latest pytest services/root/tests/ -v
+      - name: Run pytest (legislative)
+        run: docker run --rm -e DJANGO_SETTINGS_MODULE=legislative.settings app:latest pytest services/legislative/tests/ -v
       - name: Run pytest (proposals)
         run: docker run --rm -e DJANGO_SETTINGS_MODULE=legislative.settings app:latest pytest shared/proposals/tests/ -v

--- a/services/legislative/laws/services.py
+++ b/services/legislative/laws/services.py
@@ -1,0 +1,147 @@
+"""
+LAW_CHANGE 確定時の lawset 新バージョン発行と監査ログ送信（Issue #8）。
+"""
+import logging
+from django.conf import settings
+from django.utils import timezone
+
+from shared.auth import issue_jwt
+from shared.auth.scopes import AUDIT_WRITE
+
+from .models import (
+    LAWSET_ID_AMATERRACE,
+    Law,
+    Lawset,
+    LawsetMembership,
+    LawStatus,
+    compute_lawset_digest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_new_lawset_version_from_proposal(proposal):
+    """
+    確定済み LAW_CHANGE Proposal に基づき新 Lawset バージョンを発行する。
+    - 現在の LAWSET-AMATERRACE の最新版をベースに、payload の law_id に対応する Law を新 version で作成し、
+      新 Lawset (version+1) と LawsetMembership を作成する。
+    - 既存の law_id の場合は Law を law_version+1 で追加。新規 law_id の場合は Law@1 を追加し membership に含める。
+    """
+    payload = proposal.payload
+    law_id = payload.get("law_id")
+    title = payload.get("title", "")
+    text = payload.get("text", "")
+
+    current = (
+        Lawset.objects.filter(lawset_id=LAWSET_ID_AMATERRACE)
+        .order_by("-version")
+        .first()
+    )
+    if not current:
+        raise ValueError("法体系 LAWSET-AMATERRACE が存在しません。")
+
+    next_version = current.version + 1
+    effective_at = timezone.now()
+
+    # 対象 law_id の既存最新 Law を取得
+    existing_law = (
+        Law.objects.filter(law_id=law_id).order_by("-law_version").first()
+    )
+    if existing_law:
+        new_law = Law.objects.create(
+            law_id=law_id,
+            law_version=existing_law.law_version + 1,
+            title=title,
+            status=LawStatus.EFFECTIVE,
+            text=text,
+        )
+    else:
+        new_law = Law.objects.create(
+            law_id=law_id,
+            law_version=1,
+            title=title,
+            status=LawStatus.EFFECTIVE,
+            text=text,
+        )
+
+    new_lawset = Lawset.objects.create(
+        lawset_id=LAWSET_ID_AMATERRACE,
+        version=next_version,
+        effective_at=effective_at,
+        digest_hash="",  # 下で更新
+    )
+
+    # 既存 membership をコピー。対象 law_id のものは new_law に差し替え。それ以外は同じ Law。新規 law_id の場合は末尾に追加。
+    memberships_old = (
+        LawsetMembership.objects.filter(lawset=current)
+        .order_by("order", "law__law_id")
+        .select_related("law")
+    )
+    order = 0
+    replaced = False
+    for m in memberships_old:
+        if m.law.law_id == law_id:
+            LawsetMembership.objects.create(
+                lawset=new_lawset, law=new_law, order=order
+            )
+            replaced = True
+        else:
+            LawsetMembership.objects.create(
+                lawset=new_lawset, law=m.law, order=order
+            )
+        order += 1
+    if not replaced:
+        # 新規 law_id のため末尾に追加
+        LawsetMembership.objects.create(
+            lawset=new_lawset, law=new_law, order=order
+        )
+
+    parts = []
+    for m in (
+        LawsetMembership.objects.filter(lawset=new_lawset)
+        .order_by("order", "law__law_id")
+        .select_related("law")
+    ):
+        parts.append((m.law.law_id, m.law.law_version, m.law.text))
+    new_lawset.digest_hash = compute_lawset_digest(parts)
+    new_lawset.save(update_fields=["digest_hash"])
+
+    return new_lawset
+
+
+def send_audit_event(payload):
+    """
+    Root サービスの /audit/events/ に監査イベントを POST する。
+    ROOT_SERVICE_URL が未設定の場合は送信しない（開発時用）。
+    """
+    base_url = getattr(settings, "ROOT_SERVICE_URL", "").rstrip("/")
+    if not base_url:
+        logger.warning("ROOT_SERVICE_URL が未設定のため監査ログを送信しません。")
+        return
+
+    try:
+        import requests
+    except ImportError:
+        logger.warning("requests が利用できないため監査ログを送信しません。")
+        return
+
+    url = f"{base_url}/audit/events/"
+    secret = getattr(settings, "SERVICE_JWT_SECRET", "")
+    token = issue_jwt(
+        service_name=getattr(settings, "SERVICE_NAME", "legislative"),
+        scopes=[AUDIT_WRITE],
+        secret=secret,
+        expires_seconds=60,
+    )
+    resp = requests.post(
+        url,
+        json={"payload": payload},
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        timeout=10,
+    )
+    if resp.status_code not in (200, 201):
+        logger.warning(
+            "監査ログ送信失敗: %s %s", resp.status_code, resp.text[:200]
+        )
+    else:
+        logger.info("監査ログ送信成功: proposal_id=%s", payload.get("proposal_id"))

--- a/services/legislative/legislative/serializers.py
+++ b/services/legislative/legislative/serializers.py
@@ -1,0 +1,22 @@
+"""
+規範生成系（立法）サービス用シリアライザ（Issue #8）。
+"""
+from rest_framework import serializers
+
+from shared.proposals.models import LAW_ID_CONST
+
+
+class LawProposalCreateSerializer(serializers.Serializer):
+    """POST /laws/proposals/ のリクエスト body。"""
+
+    law_id = serializers.CharField(max_length=64)
+    title = serializers.CharField(max_length=256)
+    text = serializers.CharField(allow_blank=True, default="")
+    expires_at = serializers.DateTimeField(required=False)
+
+    def validate_law_id(self, value):
+        if value == LAW_ID_CONST:
+            raise serializers.ValidationError(
+                "憲法（CONST）は LAW_CHANGE の対象にできません。"
+            )
+        return value

--- a/services/legislative/legislative/settings/base.py
+++ b/services/legislative/legislative/settings/base.py
@@ -33,8 +33,12 @@ MIDDLEWARE = [
 
 SERVICE_JWT_SECRET = os.environ.get("SERVICE_JWT_SECRET", "dev-service-jwt-secret-change-in-production")
 SERVICE_NAME = os.environ.get("SERVICE_NAME", "legislative")
+# 監査ログ送信先（Issue #8）。未設定時は送信しない。
+ROOT_SERVICE_URL = os.environ.get("ROOT_SERVICE_URL", "").rstrip("/")
 # 法・法体系の参照 API および admin / Swagger。MVP では認証免除。
 SERVICE_JWT_EXEMPT_PATHS = ("/admin", "/laws/", "/lawsets/", "/schema", "/swagger")
+# /laws/ のうち JWT 必須にするプレフィックス（提案・確定は認証必須）
+SERVICE_JWT_NO_EXEMPT_PREFIXES = ("/laws/proposals",)
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [],

--- a/services/legislative/legislative/urls.py
+++ b/services/legislative/legislative/urls.py
@@ -6,6 +6,8 @@ from . import views
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("laws/proposals/", views.LawProposalCreateView.as_view(), name="law-proposal-create"),
+    path("laws/proposals/<uuid:id>/finalize/", views.LawProposalFinalizeView.as_view(), name="law-proposal-finalize"),
     path("laws/<str:law_id>/", views.LawDetailView.as_view(), name="law-detail"),
     path("lawsets/current/", views.LawsetCurrentView.as_view(), name="lawset-current"),
     path("schema/", SpectacularAPIView.as_view(), name="schema"),

--- a/services/legislative/legislative/views.py
+++ b/services/legislative/legislative/views.py
@@ -1,11 +1,27 @@
 """
 規範生成系（立法）サービス API。法・法体系の参照用（Issue #20）。
+LAW_CHANGE 提案・確定フロー（Issue #8）。
 """
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework import serializers
+
+from shared.auth.permissions import RequireScope
+from shared.auth.scopes import PROPOSAL_WRITE, PROPOSAL_FINALIZE
+from shared.proposals.models import (
+    Proposal,
+    ProposalKind,
+    ProposalOrigin,
+    ProposalStatus,
+    FinalizeConflictError,
+)
 
 from laws.models import Law, Lawset, LAWSET_ID_AMATERRACE
+from laws.services import (
+    create_new_lawset_version_from_proposal,
+    send_audit_event,
+)
 
 
 class LawDetailView(APIView):
@@ -84,6 +100,128 @@ class LawsetCurrentView(APIView):
                 "digest_hash": lawset.digest_hash,
                 "laws": laws,
                 "created_at": lawset.created_at.isoformat(),
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+# --- LAW_CHANGE 提案・確定（Issue #8） ---
+
+
+class LawProposalCreateSerializer(serializers.Serializer):
+    """POST /laws/proposals/ のリクエスト body。"""
+
+    law_id = serializers.CharField(max_length=64)
+    title = serializers.CharField(max_length=256)
+    text = serializers.CharField(allow_blank=True, default="")
+    expires_at = serializers.DateTimeField(required=False)
+
+    def validate_law_id(self, value):
+        from shared.proposals.models import LAW_ID_CONST
+        if value == LAW_ID_CONST:
+            raise serializers.ValidationError(
+                "憲法（CONST）は LAW_CHANGE の対象にできません。"
+            )
+        return value
+
+
+class LawProposalCreateView(APIView):
+    """
+    POST /laws/proposals/
+    LAW_CHANGE 提案を作成する。proposal.write スコープ必須。
+    """
+
+    permission_classes = [RequireScope]
+    required_scope = PROPOSAL_WRITE
+
+    def post(self, request):
+        ser = LawProposalCreateSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        data = ser.validated_data
+        from django.utils import timezone
+        expires_at = data.get("expires_at")
+        if expires_at is None:
+            expires_at = timezone.now() + timezone.timedelta(days=30)
+        payload = {
+            "law_id": data["law_id"],
+            "title": data["title"],
+            "text": data.get("text", ""),
+        }
+        proposal = Proposal.objects.create(
+            kind=ProposalKind.LAW_CHANGE,
+            origin=ProposalOrigin.LEGISLATIVE,
+            status=ProposalStatus.PENDING,
+            law_context={"lawset_id": LAWSET_ID_AMATERRACE},
+            payload=payload,
+            expires_at=expires_at,
+        )
+        return Response(
+            {
+                "proposal_id": str(proposal.proposal_id),
+                "kind": proposal.kind,
+                "origin": proposal.origin,
+                "status": proposal.status,
+                "payload": proposal.payload,
+                "expires_at": proposal.expires_at.isoformat(),
+                "created_at": proposal.created_at.isoformat(),
+            },
+            status=status.HTTP_201_CREATED,
+        )
+
+
+class LawProposalFinalizeView(APIView):
+    """
+    POST /laws/proposals/{id}/finalize/
+    承認2件済みの Proposal を確定し、新 lawset version を発行する。proposal.finalize スコープ必須。
+    不正な場合は 409 Conflict。
+    """
+
+    permission_classes = [RequireScope]
+    required_scope = PROPOSAL_FINALIZE
+
+    def post(self, request, id):
+        try:
+            proposal = Proposal.objects.get(proposal_id=id)
+        except Proposal.DoesNotExist:
+            return Response(
+                {"detail": "指定された提案が見つかりません。"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        if proposal.kind != ProposalKind.LAW_CHANGE:
+            return Response(
+                {"detail": "LAW_CHANGE 以外の提案はこのエンドポイントでは確定できません。"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            proposal.finalize()
+        except FinalizeConflictError as e:
+            return Response(
+                {"detail": str(e)},
+                status=status.HTTP_409_CONFLICT,
+            )
+        # 新 lawset version 発行
+        try:
+            new_lawset = create_new_lawset_version_from_proposal(proposal)
+        except Exception as e:
+            return Response(
+                {"detail": f"法体系の更新に失敗しました: {e}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        # 監査ログ送信
+        send_audit_event({
+            "event_type": "LAW_FINALIZED",
+            "proposal_id": str(proposal.proposal_id),
+            "lawset_id": new_lawset.lawset_id,
+            "version": new_lawset.version,
+            "effective_at": new_lawset.effective_at.isoformat(),
+        })
+        return Response(
+            {
+                "proposal_id": str(proposal.proposal_id),
+                "status": proposal.status,
+                "lawset_id": new_lawset.lawset_id,
+                "version": new_lawset.version,
+                "effective_at": new_lawset.effective_at.isoformat(),
             },
             status=status.HTTP_200_OK,
         )

--- a/services/legislative/legislative/views.py
+++ b/services/legislative/legislative/views.py
@@ -2,10 +2,10 @@
 規範生成系（立法）サービス API。法・法体系の参照用（Issue #20）。
 LAW_CHANGE 提案・確定フロー（Issue #8）。
 """
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework import serializers
 
 from shared.auth.permissions import RequireScope
 from shared.auth.scopes import PROPOSAL_WRITE, PROPOSAL_FINALIZE
@@ -22,6 +22,8 @@ from laws.services import (
     create_new_lawset_version_from_proposal,
     send_audit_event,
 )
+
+from .serializers import LawProposalCreateSerializer
 
 
 class LawDetailView(APIView):
@@ -108,23 +110,6 @@ class LawsetCurrentView(APIView):
 # --- LAW_CHANGE 提案・確定（Issue #8） ---
 
 
-class LawProposalCreateSerializer(serializers.Serializer):
-    """POST /laws/proposals/ のリクエスト body。"""
-
-    law_id = serializers.CharField(max_length=64)
-    title = serializers.CharField(max_length=256)
-    text = serializers.CharField(allow_blank=True, default="")
-    expires_at = serializers.DateTimeField(required=False)
-
-    def validate_law_id(self, value):
-        from shared.proposals.models import LAW_ID_CONST
-        if value == LAW_ID_CONST:
-            raise serializers.ValidationError(
-                "憲法（CONST）は LAW_CHANGE の対象にできません。"
-            )
-        return value
-
-
 class LawProposalCreateView(APIView):
     """
     POST /laws/proposals/
@@ -138,7 +123,6 @@ class LawProposalCreateView(APIView):
         ser = LawProposalCreateSerializer(data=request.data)
         ser.is_valid(raise_exception=True)
         data = ser.validated_data
-        from django.utils import timezone
         expires_at = data.get("expires_at")
         if expires_at is None:
             expires_at = timezone.now() + timezone.timedelta(days=30)

--- a/services/legislative/tests/test_laws_proposals_api.py
+++ b/services/legislative/tests/test_laws_proposals_api.py
@@ -1,0 +1,201 @@
+"""
+LAW_CHANGE 提案・確定 API のテスト（Issue #8）。
+
+- POST /laws/proposals/ で提案作成（proposal.write 必須）
+- POST /laws/proposals/{id}/finalize/ で確定（承認2件必須）、不正時は 409
+- 正常系で lawset version 更新
+"""
+import pytest
+from django.conf import settings
+from django.test import Client
+from django.utils import timezone
+
+from shared.auth import issue_jwt
+from shared.auth.scopes import PROPOSAL_WRITE, PROPOSAL_FINALIZE, APPROVAL_WRITE
+from shared.proposals.models import (
+    Proposal,
+    Approval,
+    ProposalKind,
+    ProposalOrigin,
+    ProposalStatus,
+    REQUIRED_APPROVALS,
+)
+from laws.models import Lawset, LAWSET_ID_AMATERRACE
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+def _jwt(scopes, service_name="legislative"):
+    secret = getattr(settings, "SERVICE_JWT_SECRET", "dev-service-jwt-secret-change-in-production")
+    return issue_jwt(service_name=service_name, scopes=scopes, secret=secret, expires_seconds=3600)
+
+
+@pytest.fixture
+def token_proposal_write():
+    return _jwt([PROPOSAL_WRITE])
+
+
+@pytest.fixture
+def token_proposal_finalize():
+    return _jwt([PROPOSAL_FINALIZE])
+
+
+def _future():
+    return timezone.now() + timezone.timedelta(days=1)
+
+
+# --- POST /laws/proposals/ ---
+
+
+@pytest.mark.django_db
+def test_laws_proposals_post_without_jwt_returns_401(client):
+    """POST /laws/proposals/ は JWT 必須。未送信時は 401。"""
+    response = client.post(
+        "/laws/proposals/",
+        data={
+            "law_id": "L-001",
+            "title": "某法の新設",
+            "text": "本法は試験用です。",
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_laws_proposals_post_with_scope_creates_proposal(client, token_proposal_write):
+    """POST /laws/proposals/ で proposal.write ありなら LAW_CHANGE 提案が作成される。"""
+    response = client.post(
+        "/laws/proposals/",
+        data={
+            "law_id": "L-001",
+            "title": "某法の新設",
+            "text": "本法は試験用です。",
+        },
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token_proposal_write}",
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["kind"] == ProposalKind.LAW_CHANGE
+    assert data["origin"] == ProposalOrigin.LEGISLATIVE
+    assert data["status"] == ProposalStatus.PENDING
+    assert data["payload"]["law_id"] == "L-001"
+    assert data["payload"]["title"] == "某法の新設"
+    assert "proposal_id" in data
+    proposal = Proposal.objects.get(proposal_id=data["proposal_id"])
+    assert proposal.kind == ProposalKind.LAW_CHANGE
+    assert proposal.origin == ProposalOrigin.LEGISLATIVE
+
+
+@pytest.mark.django_db
+def test_laws_proposals_post_const_rejected(client, token_proposal_write):
+    """POST /laws/proposals/ で law_id=CONST は 400。"""
+    response = client.post(
+        "/laws/proposals/",
+        data={
+            "law_id": "CONST",
+            "title": "憲法改正",
+            "text": "対象外",
+        },
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token_proposal_write}",
+    )
+    assert response.status_code == 400
+
+
+# --- POST /laws/proposals/{id}/finalize/ ---
+
+
+@pytest.fixture
+def proposal_with_two_approvals(db):
+    """承認2件付きの PENDING Proposal（finalize 可能）。"""
+    future = timezone.now() + timezone.timedelta(days=1)
+    p = Proposal.objects.create(
+        kind=ProposalKind.LAW_CHANGE,
+        origin=ProposalOrigin.LEGISLATIVE,
+        status=ProposalStatus.PENDING,
+        law_context={"lawset_id": LAWSET_ID_AMATERRACE},
+        payload={"law_id": "L-002", "title": "某法改正案", "text": "改正後の本文"},
+        expires_at=future,
+    )
+    Approval.objects.create(
+        proposal=p,
+        by=ProposalOrigin.JUDICIARY,
+        reason="本法案は手続きおよび実体規定に適合することを確認した。",
+        references=["憲法第73条"],
+    )
+    Approval.objects.create(
+        proposal=p,
+        by=ProposalOrigin.EXECUTIVE,
+        reason="本法案は執行上問題ないと判断した。承認する。（20文字以上）",
+        references=["憲法第72条"],
+    )
+    return p
+
+
+@pytest.mark.django_db
+def test_laws_proposals_finalize_success_updates_lawset_version(
+    client, token_proposal_finalize, proposal_with_two_approvals
+):
+    """正常系: finalize で lawset の新 version が発行される。"""
+    pid = proposal_with_two_approvals.proposal_id
+    current = Lawset.objects.filter(lawset_id=LAWSET_ID_AMATERRACE).order_by("-version").first()
+    assert current is not None
+    prev_version = current.version
+
+    response = client.post(
+        f"/laws/proposals/{pid}/finalize/",
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token_proposal_finalize}",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == ProposalStatus.FINALIZED
+    assert data["lawset_id"] == LAWSET_ID_AMATERRACE
+    assert data["version"] == prev_version + 1
+
+    proposal_with_two_approvals.refresh_from_db()
+    assert proposal_with_two_approvals.status == ProposalStatus.FINALIZED
+
+    new_lawset = Lawset.objects.get(lawset_id=LAWSET_ID_AMATERRACE, version=prev_version + 1)
+    assert new_lawset.digest_hash
+
+
+@pytest.mark.django_db
+def test_laws_proposals_finalize_without_approvals_returns_409(
+    client, token_proposal_finalize
+):
+    """承認0件の Proposal を finalize すると 409。"""
+    future = timezone.now() + timezone.timedelta(days=1)
+    p = Proposal.objects.create(
+        kind=ProposalKind.LAW_CHANGE,
+        origin=ProposalOrigin.LEGISLATIVE,
+        status=ProposalStatus.PENDING,
+        law_context={},
+        payload={"law_id": "L-003", "title": "未承認案", "text": ""},
+        expires_at=future,
+    )
+    response = client.post(
+        f"/laws/proposals/{p.proposal_id}/finalize/",
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token_proposal_finalize}",
+    )
+    assert response.status_code == 409
+    p.refresh_from_db()
+    assert p.status == ProposalStatus.PENDING
+
+
+@pytest.mark.django_db
+def test_laws_proposals_finalize_not_found_returns_404(client, token_proposal_finalize):
+    """存在しない proposal_id で finalize すると 404。"""
+    import uuid
+    response = client.post(
+        f"/laws/proposals/{uuid.uuid4()}/finalize/",
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token_proposal_finalize}",
+    )
+    assert response.status_code == 404

--- a/shared/auth/middleware.py
+++ b/shared/auth/middleware.py
@@ -29,7 +29,11 @@ class ServiceJWTAuthenticationMiddleware:
     def __call__(self, request):
         exempt_paths = get_exempt_paths()
         path = request.path.rstrip("/") or "/"
-        if any(path == p.rstrip("/") or path.startswith(p.rstrip("/") + "/") for p in exempt_paths):
+        # 除外プレフィックスがあれば exempt にしない（例: /laws/proposals は JWT 必須）
+        no_exempt_prefixes = getattr(settings, "SERVICE_JWT_NO_EXEMPT_PREFIXES", ())
+        if no_exempt_prefixes and any(path.startswith(p.rstrip("/")) for p in no_exempt_prefixes):
+            pass  # JWT 必須のためこのまま検証へ
+        elif any(path == p.rstrip("/") or path.startswith(p.rstrip("/") + "/") for p in exempt_paths):
             return self.get_response(request)
 
         auth_header = request.META.get("HTTP_AUTHORIZATION") or ""


### PR DESCRIPTION
## 概要
Issue #8「規範生成系 LAW_CHANGE フロー実装」の実装です。

## 実装内容
- **POST /laws/proposals/** … LAW_CHANGE 提案を作成（`proposal.write` スコープ必須）
- **POST /laws/proposals/{id}/finalize/** … 承認2件済みの提案を確定（`proposal.finalize` スコープ必須）
  - 不正な確定試行時は **409 Conflict** を返却
  - 正常時は新 **lawset version** を発行し、**監査ログ**を Root の `/audit/events/` に送信

## 主な変更
- `services/legislative/legislative/views.py` … 提案作成・確定 API を追加
- `services/legislative/laws/services.py` … 新規追加: lawset 新バージョン発行ロジックと監査送信
- `services/legislative/legislative/urls.py` … `laws/proposals/` と `laws/proposals/<uuid>/finalize/` を追加
- `shared/auth/middleware.py` … `SERVICE_JWT_NO_EXEMPT_PREFIXES` を追加し、`/laws/proposals` を JWT 必須に
- `services/legislative/legislative/settings/base.py` … `ROOT_SERVICE_URL` と `SERVICE_JWT_NO_EXEMPT_PREFIXES` を追加
- テスト: `services/legislative/tests/test_laws_proposals_api.py` を追加（正常系・不正承認時 409・404）

## 完了条件の充足
- 正常系で lawset version 更新 … ✅ テスト `test_laws_proposals_finalize_success_updates_lawset_version` で検証
- 不正承認時は 409 … ✅ テスト `test_laws_proposals_finalize_without_approvals_returns_409` で検証

Closes #8
