### PR TITLE
[codex] Implement request tracing middleware

### DIFF
--- a/services/executive/exec/services.py
+++ b/services/executive/exec/services.py
@@ -6,10 +6,20 @@ from django.conf import settings
 
 from shared.auth import issue_jwt
 from shared.auth.scopes import AUDIT_WRITE, INDEX_WRITE, PROPOSAL_FINALIZE
+from shared.tracing import REQUEST_ID_HEADER, get_current_request_id, normalize_request_id
 
 from .models import ExecutionQueueItem
 
 logger = logging.getLogger(__name__)
+
+
+def _request_id_headers(request_id=None):
+    current_request_id = normalize_request_id(request_id) or normalize_request_id(
+        get_current_request_id()
+    )
+    if not current_request_id:
+        return {}
+    return {REQUEST_ID_HEADER: current_request_id}
 
 
 def enqueue_execution(proposal_id):
@@ -23,7 +33,7 @@ def enqueue_execution(proposal_id):
     logger.info("実行キューに追加: proposal_id=%s", proposal_id)
 
 
-def send_audit_event(payload):
+def send_audit_event(payload, request_id=None):
     """
     Root サービスの /audit/events/ に監査イベントを POST する。
     ROOT_SERVICE_URL が未設定の場合は送信しない（開発時用）。
@@ -51,7 +61,11 @@ def send_audit_event(payload):
         resp = requests.post(
             url,
             json={"payload": payload},
-            headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                **_request_id_headers(request_id),
+            },
             timeout=10,
         )
         if resp.status_code not in (200, 201):
@@ -64,7 +78,7 @@ def send_audit_event(payload):
         logger.warning("監査ログ送信エラー（接続失敗等）: %s", e)
 
 
-def register_index(proposal):
+def register_index(proposal, request_id=None):
     """Root の索引に Proposal を登録する（Issue #10）。"""
     base_url = getattr(settings, "ROOT_SERVICE_URL", "").rstrip("/")
     if not base_url:
@@ -96,7 +110,11 @@ def register_index(proposal):
         resp = requests.post(
             url,
             json=payload,
-            headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                **_request_id_headers(request_id),
+            },
             timeout=10,
         )
         if resp.status_code not in (200, 201):
@@ -107,7 +125,7 @@ def register_index(proposal):
         logger.warning("索引登録エラー: %s", e)
 
 
-def update_index_status(proposal_id, status, finalized_at=None):
+def update_index_status(proposal_id, status, finalized_at=None, request_id=None):
     """Root の索引の status を更新する（Issue #10）。"""
     base_url = getattr(settings, "ROOT_SERVICE_URL", "").rstrip("/")
     if not base_url:
@@ -133,7 +151,11 @@ def update_index_status(proposal_id, status, finalized_at=None):
         resp = requests.patch(
             url,
             json=payload,
-            headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                **_request_id_headers(request_id),
+            },
             timeout=10,
         )
         if resp.status_code != 200:
@@ -144,7 +166,7 @@ def update_index_status(proposal_id, status, finalized_at=None):
         logger.warning("索引更新エラー: %s", e)
 
 
-def fetch_approvals_from_service(base_url, proposal_id):
+def fetch_approvals_from_service(base_url, proposal_id, request_id=None):
     """他サービスの GET /approvals?proposal_id=xxx を呼び、承認リストを返す。"""
     if not base_url:
         return []
@@ -164,13 +186,18 @@ def fetch_approvals_from_service(base_url, proposal_id):
         resp = requests.get(
             url,
             params={"proposal_id": str(proposal_id)},
-            headers={"Authorization": f"Bearer {token}"},
+            headers={
+                "Authorization": f"Bearer {token}",
+                **_request_id_headers(request_id),
+            },
             timeout=10,
         )
     except requests.exceptions.RequestException:
         return []
     if resp.status_code != 200:
-        logger.warning("承認取得失敗 %s: %s %s", base_url, resp.status_code, resp.text[:200])
+        logger.warning(
+            "承認取得失敗 %s: %s %s", base_url, resp.status_code, resp.text[:200]
+        )
         return []
     data = resp.json()
     if not isinstance(data, list):
@@ -178,5 +205,8 @@ def fetch_approvals_from_service(base_url, proposal_id):
     return [
         {"by": item["by"], "reason": item["reason"], "references": item["references"]}
         for item in data
-        if isinstance(item, dict) and "by" in item and "reason" in item and "references" in item
+        if isinstance(item, dict)
+        and "by" in item
+        and "reason" in item
+        and "references" in item
     ]

--- a/services/executive/exec/views.py
+++ b/services/executive/exec/views.py
@@ -139,7 +139,7 @@ class ExecProposalCreateView(APIView):
             payload=payload,
             expires_at=expires_at,
         )
-        register_index(proposal)
+        register_index(proposal, request_id=request.request_id)
         return Response(
             {
                 "proposal_id": str(proposal.proposal_id),
@@ -180,8 +180,20 @@ class ExecProposalFinalizeView(APIView):
         judiciary_url = getattr(settings, "JUDICIARY_SERVICE_URL", "").rstrip("/")
         legislative_url = getattr(settings, "LEGISLATIVE_SERVICE_URL", "").rstrip("/")
         external = []
-        external.extend(fetch_approvals_from_service(judiciary_url, id))
-        external.extend(fetch_approvals_from_service(legislative_url, id))
+        external.extend(
+            fetch_approvals_from_service(
+                judiciary_url,
+                id,
+                request_id=request.request_id,
+            )
+        )
+        external.extend(
+            fetch_approvals_from_service(
+                legislative_url,
+                id,
+                request_id=request.request_id,
+            )
+        )
         try:
             proposal.finalize_with_approvals(external)
         except FinalizeConflictError as e:
@@ -190,12 +202,20 @@ class ExecProposalFinalizeView(APIView):
                 status=status.HTTP_409_CONFLICT,
             )
         enqueue_execution(proposal.proposal_id)
-        send_audit_event({
-            "event_type": "EXEC_ACTION_FINALIZED",
-            "proposal_id": str(proposal.proposal_id),
-            "payload": proposal.payload,
-        })
-        update_index_status(proposal.proposal_id, ProposalStatus.FINALIZED, proposal.finalized_at)
+        send_audit_event(
+            {
+                "event_type": "EXEC_ACTION_FINALIZED",
+                "proposal_id": str(proposal.proposal_id),
+                "payload": proposal.payload,
+            },
+            request_id=request.request_id,
+        )
+        update_index_status(
+            proposal.proposal_id,
+            ProposalStatus.FINALIZED,
+            proposal.finalized_at,
+            request_id=request.request_id,
+        )
         return Response(
             {
                 "proposal_id": str(proposal.proposal_id),

--- a/services/executive/executive/settings/base.py
+++ b/services/executive/executive/settings/base.py
@@ -23,6 +23,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "shared.tracing.middleware.RequestTracingMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -51,6 +52,32 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "秩序実行系（行政）サービス API",
     "VERSION": "0.1.0",
     "SERVE_INCLUDE_SCHEMA": False,
+}
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {
+        "request_id": {
+            "()": "shared.tracing.middleware.RequestIdLogFilter",
+        },
+    },
+    "formatters": {
+        "standard": {
+            "format": "%(levelname)s %(asctime)s %(name)s request_id=%(request_id)s %(message)s",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "filters": ["request_id"],
+            "formatter": "standard",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": os.environ.get("LOG_LEVEL", "INFO"),
+    },
 }
 
 TEMPLATES = [

--- a/services/executive/tests/test_exec_proposals_api.py
+++ b/services/executive/tests/test_exec_proposals_api.py
@@ -60,14 +60,18 @@ def test_exec_proposals_post_without_jwt_returns_401(client):
 def test_exec_proposals_post_with_scope_creates_proposal(client, token_proposal_write):
     """POST /exec/proposals/ で proposal.write ありなら EXEC_ACTION 提案が作成される。"""
     from unittest.mock import patch
-    with patch("exec.views.register_index"):
+    request_id = "exec-create-request"
+    with patch("exec.views.register_index") as mock_register_index:
         response = client.post(
             "/exec/proposals/",
             data={"payload": {"action": "NOTIFY", "target": "user-1"}},
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token_proposal_write}",
+            HTTP_X_REQUEST_ID=request_id,
         )
     assert response.status_code == 201
+    assert response["X-Request-Id"] == request_id
+    assert mock_register_index.call_args.kwargs["request_id"] == request_id
     data = response.json()
     assert data["kind"] == ProposalKind.EXEC_ACTION
     assert data["origin"] == ProposalOrigin.EXECUTIVE
@@ -120,16 +124,23 @@ def test_exec_proposals_finalize_success_enqueues_and_returns_200(
         {"by": "JUDICIARY", "reason": "本法案は手続きおよび実体規定に適合する。", "references": ["憲法第81条"]},
         {"by": "LEGISLATIVE", "reason": "本法案は執行上問題ないと判断した。承認する。（20文字以上）", "references": ["憲法第72条"]},
     ]
+    request_id = "exec-finalize-request"
     with patch("exec.views.fetch_approvals_from_service") as mock_fetch, patch(
         "exec.views.update_index_status"
-    ):
+    ) as mock_update_index_status, patch("exec.views.send_audit_event") as mock_send_audit_event:
         mock_fetch.side_effect = [[external[0]], [external[1]]]
         response = client.post(
             f"/exec/proposals/{pid}/finalize/",
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token_proposal_finalize}",
+            HTTP_X_REQUEST_ID=request_id,
         )
     assert response.status_code == 200
+    assert response["X-Request-Id"] == request_id
+    assert mock_fetch.call_args_list[0].kwargs["request_id"] == request_id
+    assert mock_fetch.call_args_list[1].kwargs["request_id"] == request_id
+    assert mock_send_audit_event.call_args.kwargs["request_id"] == request_id
+    assert mock_update_index_status.call_args.kwargs["request_id"] == request_id
     data = response.json()
     assert data["status"] == ProposalStatus.FINALIZED
     assert data["proposal_id"] == str(pid)
@@ -190,3 +201,56 @@ def test_exec_proposals_finalize_wrong_kind_returns_400(client, token_proposal_f
         HTTP_AUTHORIZATION=f"Bearer {token_proposal_finalize}",
     )
     assert response.status_code == 400
+
+
+def test_executive_internal_http_calls_propagate_request_id(settings):
+    """Root/他サービスへの内部 HTTP 呼び出しは X-Request-Id を伝播する。"""
+    from types import SimpleNamespace
+    from unittest.mock import Mock, patch
+
+    from exec.services import (
+        fetch_approvals_from_service,
+        register_index,
+        send_audit_event,
+        update_index_status,
+    )
+
+    settings.ROOT_SERVICE_URL = "http://root"
+    settings.SERVICE_JWT_SECRET = "test-secret"
+    settings.SERVICE_NAME = "executive"
+    request_id = "executive-service-request"
+    now = timezone.now()
+    proposal = SimpleNamespace(
+        proposal_id=uuid.uuid4(),
+        kind=ProposalKind.EXEC_ACTION,
+        origin=ProposalOrigin.EXECUTIVE,
+        status=ProposalStatus.PENDING,
+        payload={"action": "TRACE"},
+        created_at=now,
+        expires_at=now + timezone.timedelta(days=30),
+    )
+
+    with patch("requests.post") as mock_post, patch("requests.patch") as mock_patch, patch(
+        "requests.get"
+    ) as mock_get:
+        mock_post.return_value = Mock(status_code=201, text="")
+        mock_patch.return_value = Mock(status_code=200, text="")
+        mock_get.return_value = Mock(
+            status_code=200,
+            text="",
+            json=Mock(
+                return_value=[
+                    {"by": "JUDICIARY", "reason": "十分な理由を伴う承認です。", "references": ["REF"]}
+                ]
+            ),
+        )
+
+        send_audit_event({"event_type": "EXEC_ACTION_FINALIZED"}, request_id=request_id)
+        register_index(proposal, request_id=request_id)
+        update_index_status(proposal.proposal_id, ProposalStatus.FINALIZED, now, request_id=request_id)
+        fetch_approvals_from_service("http://judiciary", proposal.proposal_id, request_id=request_id)
+
+    for call in mock_post.call_args_list:
+        assert call.kwargs["headers"]["X-Request-Id"] == request_id
+    assert mock_patch.call_args.kwargs["headers"]["X-Request-Id"] == request_id
+    assert mock_get.call_args.kwargs["headers"]["X-Request-Id"] == request_id

--- a/services/judiciary/judiciary/settings/base.py
+++ b/services/judiciary/judiciary/settings/base.py
@@ -23,6 +23,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "shared.tracing.middleware.RequestTracingMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -47,6 +48,32 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "法則審査系（司法）サービス API",
     "VERSION": "0.1.0",
     "SERVE_INCLUDE_SCHEMA": False,
+}
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {
+        "request_id": {
+            "()": "shared.tracing.middleware.RequestIdLogFilter",
+        },
+    },
+    "formatters": {
+        "standard": {
+            "format": "%(levelname)s %(asctime)s %(name)s request_id=%(request_id)s %(message)s",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "filters": ["request_id"],
+            "formatter": "standard",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": os.environ.get("LOG_LEVEL", "INFO"),
+    },
 }
 
 TEMPLATES = [

--- a/services/legislative/laws/services.py
+++ b/services/legislative/laws/services.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from shared.auth import issue_jwt
 from shared.auth.scopes import AUDIT_WRITE, INDEX_WRITE, PROPOSAL_FINALIZE
+from shared.tracing import REQUEST_ID_HEADER, get_current_request_id, normalize_request_id
 
 from .models import (
     LAWSET_ID_AMATERRACE,
@@ -18,6 +19,15 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _request_id_headers(request_id=None):
+    current_request_id = normalize_request_id(request_id) or normalize_request_id(
+        get_current_request_id()
+    )
+    if not current_request_id:
+        return {}
+    return {REQUEST_ID_HEADER: current_request_id}
 
 
 def create_new_lawset_version_from_proposal(proposal):
@@ -109,7 +119,7 @@ def create_new_lawset_version_from_proposal(proposal):
     return new_lawset
 
 
-def send_audit_event(payload):
+def send_audit_event(payload, request_id=None):
     """
     Root サービスの /audit/events/ に監査イベントを POST する。
     ROOT_SERVICE_URL が未設定の場合は送信しない（開発時用）。
@@ -136,7 +146,11 @@ def send_audit_event(payload):
     resp = requests.post(
         url,
         json={"payload": payload},
-        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            **_request_id_headers(request_id),
+        },
         timeout=10,
     )
     if resp.status_code not in (200, 201):
@@ -147,7 +161,7 @@ def send_audit_event(payload):
         logger.info("監査ログ送信成功: proposal_id=%s", payload.get("proposal_id"))
 
 
-def register_index(proposal):
+def register_index(proposal, request_id=None):
     """
     Root の索引に Proposal を登録する（Issue #10）。提案作成後に発議元が呼ぶ。
     """
@@ -180,7 +194,11 @@ def register_index(proposal):
     resp = requests.post(
         url,
         json=payload,
-        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            **_request_id_headers(request_id),
+        },
         timeout=10,
     )
     if resp.status_code not in (200, 201):
@@ -189,7 +207,7 @@ def register_index(proposal):
         logger.info("索引登録成功: proposal_id=%s", proposal.proposal_id)
 
 
-def update_index_status(proposal_id, status, finalized_at=None):
+def update_index_status(proposal_id, status, finalized_at=None, request_id=None):
     """Root の索引の status を更新する（Issue #10）。finalize 成功後に発議元が呼ぶ。"""
     base_url = getattr(settings, "ROOT_SERVICE_URL", "").rstrip("/")
     if not base_url:
@@ -214,7 +232,11 @@ def update_index_status(proposal_id, status, finalized_at=None):
     resp = requests.patch(
         url,
         json=payload,
-        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            **_request_id_headers(request_id),
+        },
         timeout=10,
     )
     if resp.status_code != 200:
@@ -223,7 +245,7 @@ def update_index_status(proposal_id, status, finalized_at=None):
         logger.info("索引更新成功: proposal_id=%s status=%s", proposal_id, status)
 
 
-def fetch_approvals_from_service(base_url, proposal_id):
+def fetch_approvals_from_service(base_url, proposal_id, request_id=None):
     """
     他サービスの GET /approvals?proposal_id=xxx を呼び、承認リストを返す。
     戻り値: list[dict] 各要素は {"by": str, "reason": str, "references": list}
@@ -246,11 +268,16 @@ def fetch_approvals_from_service(base_url, proposal_id):
     resp = requests.get(
         url,
         params={"proposal_id": str(proposal_id)},
-        headers={"Authorization": f"Bearer {token}"},
+        headers={
+            "Authorization": f"Bearer {token}",
+            **_request_id_headers(request_id),
+        },
         timeout=10,
     )
     if resp.status_code != 200:
-        logger.warning("承認取得失敗 %s: %s %s", base_url, resp.status_code, resp.text[:200])
+        logger.warning(
+            "承認取得失敗 %s: %s %s", base_url, resp.status_code, resp.text[:200]
+        )
         return []
     data = resp.json()
     if not isinstance(data, list):
@@ -258,5 +285,8 @@ def fetch_approvals_from_service(base_url, proposal_id):
     return [
         {"by": item["by"], "reason": item["reason"], "references": item["references"]}
         for item in data
-        if isinstance(item, dict) and "by" in item and "reason" in item and "references" in item
+        if isinstance(item, dict)
+        and "by" in item
+        and "reason" in item
+        and "references" in item
     ]

--- a/services/legislative/legislative/settings/base.py
+++ b/services/legislative/legislative/settings/base.py
@@ -23,6 +23,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "shared.tracing.middleware.RequestTracingMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -55,6 +56,32 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "規範生成系（立法）サービス API（法・法体系参照）",
     "VERSION": "0.1.0",
     "SERVE_INCLUDE_SCHEMA": False,
+}
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {
+        "request_id": {
+            "()": "shared.tracing.middleware.RequestIdLogFilter",
+        },
+    },
+    "formatters": {
+        "standard": {
+            "format": "%(levelname)s %(asctime)s %(name)s request_id=%(request_id)s %(message)s",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "filters": ["request_id"],
+            "formatter": "standard",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": os.environ.get("LOG_LEVEL", "INFO"),
+    },
 }
 
 TEMPLATES = [

--- a/services/legislative/legislative/views.py
+++ b/services/legislative/legislative/views.py
@@ -210,7 +210,7 @@ class LawProposalCreateView(APIView):
             payload=payload,
             expires_at=expires_at,
         )
-        register_index(proposal)
+        register_index(proposal, request_id=request.request_id)
         return Response(
             {
                 "proposal_id": str(proposal.proposal_id),
@@ -252,8 +252,20 @@ class LawProposalFinalizeView(APIView):
         judiciary_url = getattr(settings, "JUDICIARY_SERVICE_URL", "").rstrip("/")
         executive_url = getattr(settings, "EXECUTIVE_SERVICE_URL", "").rstrip("/")
         external = []
-        external.extend(fetch_approvals_from_service(judiciary_url, id))
-        external.extend(fetch_approvals_from_service(executive_url, id))
+        external.extend(
+            fetch_approvals_from_service(
+                judiciary_url,
+                id,
+                request_id=request.request_id,
+            )
+        )
+        external.extend(
+            fetch_approvals_from_service(
+                executive_url,
+                id,
+                request_id=request.request_id,
+            )
+        )
         try:
             proposal.finalize_with_approvals(external)
         except FinalizeConflictError as e:
@@ -270,14 +282,22 @@ class LawProposalFinalizeView(APIView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         # 監査ログ送信
-        send_audit_event({
-            "event_type": "LAW_FINALIZED",
-            "proposal_id": str(proposal.proposal_id),
-            "lawset_id": new_lawset.lawset_id,
-            "version": new_lawset.version,
-            "effective_at": new_lawset.effective_at.isoformat(),
-        })
-        update_index_status(proposal.proposal_id, ProposalStatus.FINALIZED, proposal.finalized_at)
+        send_audit_event(
+            {
+                "event_type": "LAW_FINALIZED",
+                "proposal_id": str(proposal.proposal_id),
+                "lawset_id": new_lawset.lawset_id,
+                "version": new_lawset.version,
+                "effective_at": new_lawset.effective_at.isoformat(),
+            },
+            request_id=request.request_id,
+        )
+        update_index_status(
+            proposal.proposal_id,
+            ProposalStatus.FINALIZED,
+            proposal.finalized_at,
+            request_id=request.request_id,
+        )
         return Response(
             {
                 "proposal_id": str(proposal.proposal_id),

--- a/services/legislative/tests/test_laws_proposals_api.py
+++ b/services/legislative/tests/test_laws_proposals_api.py
@@ -67,7 +67,8 @@ def test_laws_proposals_post_without_jwt_returns_401(client):
 def test_laws_proposals_post_with_scope_creates_proposal(client, token_proposal_write):
     """POST /laws/proposals/ で proposal.write ありなら LAW_CHANGE 提案が作成される。"""
     from unittest.mock import patch
-    with patch("legislative.views.register_index"):
+    request_id = "law-create-request"
+    with patch("legislative.views.register_index") as mock_register_index:
         response = client.post(
             "/laws/proposals/",
             data={
@@ -77,8 +78,11 @@ def test_laws_proposals_post_with_scope_creates_proposal(client, token_proposal_
             },
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token_proposal_write}",
+            HTTP_X_REQUEST_ID=request_id,
         )
     assert response.status_code == 201
+    assert response["X-Request-Id"] == request_id
+    assert mock_register_index.call_args.kwargs["request_id"] == request_id
     data = response.json()
     assert data["kind"] == ProposalKind.LAW_CHANGE
     assert data["origin"] == ProposalOrigin.LEGISLATIVE
@@ -152,9 +156,12 @@ def test_laws_proposals_finalize_success_updates_lawset_version(
         {"by": "JUDICIARY", "reason": "本法案は手続きおよび実体規定に適合する。", "references": ["憲法第81条"]},
         {"by": "EXECUTIVE", "reason": "本法案は執行上問題ないと判断した。承認する。（20文字以上）", "references": ["憲法第72条"]},
     ]
+    request_id = "law-finalize-request"
     with patch("legislative.views.fetch_approvals_from_service") as mock_fetch, patch(
         "legislative.views.update_index_status"
-    ), patch("legislative.views.send_audit_event"):
+    ) as mock_update_index_status, patch(
+        "legislative.views.send_audit_event"
+    ) as mock_send_audit_event:
         mock_fetch.side_effect = [
             [external[0]],
             [external[1]],
@@ -163,8 +170,14 @@ def test_laws_proposals_finalize_success_updates_lawset_version(
             f"/laws/proposals/{pid}/finalize/",
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token_proposal_finalize}",
+            HTTP_X_REQUEST_ID=request_id,
         )
     assert response.status_code == 200
+    assert response["X-Request-Id"] == request_id
+    assert mock_fetch.call_args_list[0].kwargs["request_id"] == request_id
+    assert mock_fetch.call_args_list[1].kwargs["request_id"] == request_id
+    assert mock_send_audit_event.call_args.kwargs["request_id"] == request_id
+    assert mock_update_index_status.call_args.kwargs["request_id"] == request_id
     data = response.json()
     assert data["status"] == ProposalStatus.FINALIZED
     assert data["lawset_id"] == LAWSET_ID_AMATERRACE
@@ -211,3 +224,57 @@ def test_laws_proposals_finalize_not_found_returns_404(client, token_proposal_fi
         HTTP_AUTHORIZATION=f"Bearer {token_proposal_finalize}",
     )
     assert response.status_code == 404
+
+
+def test_legislative_internal_http_calls_propagate_request_id(settings):
+    """Root/他サービスへの内部 HTTP 呼び出しは X-Request-Id を伝播する。"""
+    import uuid
+    from types import SimpleNamespace
+    from unittest.mock import Mock, patch
+
+    from laws.services import (
+        fetch_approvals_from_service,
+        register_index,
+        send_audit_event,
+        update_index_status,
+    )
+
+    settings.ROOT_SERVICE_URL = "http://root"
+    settings.SERVICE_JWT_SECRET = "test-secret"
+    settings.SERVICE_NAME = "legislative"
+    request_id = "legislative-service-request"
+    now = timezone.now()
+    proposal = SimpleNamespace(
+        proposal_id=uuid.uuid4(),
+        kind=ProposalKind.LAW_CHANGE,
+        origin=ProposalOrigin.LEGISLATIVE,
+        status=ProposalStatus.PENDING,
+        payload={"law_id": "L-900", "title": "伝播確認"},
+        created_at=now,
+        expires_at=now + timezone.timedelta(days=30),
+    )
+
+    with patch("requests.post") as mock_post, patch("requests.patch") as mock_patch, patch(
+        "requests.get"
+    ) as mock_get:
+        mock_post.return_value = Mock(status_code=201, text="")
+        mock_patch.return_value = Mock(status_code=200, text="")
+        mock_get.return_value = Mock(
+            status_code=200,
+            text="",
+            json=Mock(
+                return_value=[
+                    {"by": "JUDICIARY", "reason": "十分な理由を伴う承認です。", "references": ["REF"]}
+                ]
+            ),
+        )
+
+        send_audit_event({"event_type": "LAW_FINALIZED"}, request_id=request_id)
+        register_index(proposal, request_id=request_id)
+        update_index_status(proposal.proposal_id, ProposalStatus.FINALIZED, now, request_id=request_id)
+        fetch_approvals_from_service("http://judiciary", proposal.proposal_id, request_id=request_id)
+
+    for call in mock_post.call_args_list:
+        assert call.kwargs["headers"]["X-Request-Id"] == request_id
+    assert mock_patch.call_args.kwargs["headers"]["X-Request-Id"] == request_id
+    assert mock_get.call_args.kwargs["headers"]["X-Request-Id"] == request_id

--- a/services/root/audit/admin.py
+++ b/services/root/audit/admin.py
@@ -4,10 +4,10 @@ from .models import AuditEvent
 
 @admin.register(AuditEvent)
 class AuditEventAdmin(admin.ModelAdmin):
-    list_display = ("id", "event_hash", "prev_hash", "created_at")
+    list_display = ("id", "request_id", "event_hash", "prev_hash", "created_at")
     list_filter = ("created_at",)
-    search_fields = ("event_hash", "prev_hash")
-    readonly_fields = ("prev_hash", "event_hash", "payload", "signature", "created_at")
+    search_fields = ("request_id", "event_hash", "prev_hash")
+    readonly_fields = ("request_id", "prev_hash", "event_hash", "payload", "signature", "created_at")
 
     def has_add_permission(self, request):
         return False

--- a/services/root/audit/migrations/0002_auditevent_request_id.py
+++ b/services/root/audit/migrations/0002_auditevent_request_id.py
@@ -1,0 +1,19 @@
+# Generated manually for Issue #11.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("audit", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="auditevent",
+            name="request_id",
+            field=models.CharField(db_index=True, default="", max_length=64),
+            preserve_default=False,
+        ),
+    ]

--- a/services/root/audit/models.py
+++ b/services/root/audit/models.py
@@ -34,6 +34,7 @@ class AuditEvent(models.Model):
     監査イベント。追記専用。prev_hash でチェーンし、event_hash で改ざん検出可能。
     """
 
+    request_id = models.CharField(max_length=64, db_index=True)
     prev_hash = models.CharField(max_length=64, blank=True, db_index=True)
     event_hash = models.CharField(max_length=64, unique=True, db_index=True)
     payload = models.JSONField(default=dict)
@@ -54,6 +55,8 @@ class AuditEvent(models.Model):
     def save(self, *args, **kwargs):
         if self.pk is not None:
             raise ValidationError("監査イベントは追記専用のため更新できません。")
+        if not self.request_id:
+            raise ValidationError("監査イベントには request_id が必要です。")
         if not self.event_hash:
             last = (
                 AuditEvent.objects.order_by("-created_at", "-id")

--- a/services/root/audit/serializers.py
+++ b/services/root/audit/serializers.py
@@ -7,8 +7,11 @@ class AuditEventCreateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = AuditEvent
-        fields = ("payload", "signature")
-        extra_kwargs = {"signature": {"required": False, "allow_blank": True}}
+        fields = ("payload", "request_id", "signature")
+        extra_kwargs = {
+            "request_id": {"required": False, "allow_blank": True},
+            "signature": {"required": False, "allow_blank": True},
+        }
 
 
 class AuditEventReadSerializer(serializers.ModelSerializer):
@@ -16,5 +19,13 @@ class AuditEventReadSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = AuditEvent
-        fields = ("id", "prev_hash", "event_hash", "payload", "signature", "created_at")
+        fields = (
+            "id",
+            "request_id",
+            "prev_hash",
+            "event_hash",
+            "payload",
+            "signature",
+            "created_at",
+        )
         read_only_fields = fields

--- a/services/root/audit/views.py
+++ b/services/root/audit/views.py
@@ -7,6 +7,7 @@ from drf_spectacular.utils import extend_schema
 
 from shared.auth.permissions import RequireScope
 from shared.auth.scopes import AUDIT_READ, AUDIT_WRITE
+from shared.tracing import get_current_request_id, normalize_request_id
 
 from .models import AuditEvent
 from .permissions import RequireAuditScopeForMethod
@@ -44,7 +45,17 @@ class AuditEventListCreateView(APIView):
     def post(self, request):
         serializer = AuditEventCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        request_id = (
+            normalize_request_id(getattr(request, "request_id", ""))
+            or normalize_request_id(get_current_request_id())
+            or normalize_request_id(serializer.validated_data.get("request_id"))
+        )
+        if not request_id:
+            return Response(
+                {"request_id": ["request_id is required."]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        serializer.save(request_id=request_id)
         read_serializer = AuditEventReadSerializer(instance=serializer.instance)
         return Response(read_serializer.data, status=status.HTTP_201_CREATED)
 

--- a/services/root/root/settings/base.py
+++ b/services/root/root/settings/base.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "shared.tracing.middleware.RequestTracingMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -56,6 +57,32 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "平和保障試験区 Root サービス API（公開窓口・監査・Proposal 索引）",
     "VERSION": "0.1.0",
     "SERVE_INCLUDE_SCHEMA": False,
+}
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {
+        "request_id": {
+            "()": "shared.tracing.middleware.RequestIdLogFilter",
+        },
+    },
+    "formatters": {
+        "standard": {
+            "format": "%(levelname)s %(asctime)s %(name)s request_id=%(request_id)s %(message)s",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "filters": ["request_id"],
+            "formatter": "standard",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": os.environ.get("LOG_LEVEL", "INFO"),
+    },
 }
 
 TEMPLATES = [

--- a/services/root/tests/test_audit_events.py
+++ b/services/root/tests/test_audit_events.py
@@ -1,6 +1,8 @@
 """
 監査イベント API とハッシュチェーン・append-only のテスト（Issue #5）。
 """
+import uuid
+
 import pytest
 from django.conf import settings
 from django.test import Client
@@ -51,6 +53,7 @@ def test_audit_events_post_without_jwt_returns_401(client):
     """POST /audit/events/ は JWT 必須。"""
     response = client.post("/audit/events/", data={"payload": {}}, content_type="application/json")
     assert response.status_code == 401
+    uuid.UUID(response["X-Request-Id"])
 
 
 @pytest.mark.django_db
@@ -83,14 +86,18 @@ def test_audit_events_post_without_audit_write_returns_403(client, token_read):
 @pytest.mark.django_db
 def test_audit_events_post_returns_201_and_chain(client, token_write):
     """POST で 1 件登録すると 201、prev_hash/event_hash が設定される。"""
+    request_id = "audit-request-1"
     response = client.post(
         "/audit/events/",
         data={"payload": {"action": "test", "id": 1}},
         content_type="application/json",
         HTTP_AUTHORIZATION=f"Bearer {token_write}",
+        HTTP_X_REQUEST_ID=request_id,
     )
     assert response.status_code == 201
+    assert response["X-Request-Id"] == request_id
     data = response.json()
+    assert data["request_id"] == request_id
     assert data["prev_hash"] == ""
     assert len(data["event_hash"]) == 64
     assert data["payload"] == {"action": "test", "id": 1}
@@ -106,6 +113,7 @@ def test_audit_events_hash_chain(client, token_write):
         data={"payload": {"n": 1}},
         content_type="application/json",
         HTTP_AUTHORIZATION=f"Bearer {token_write}",
+        HTTP_X_REQUEST_ID="audit-chain-1",
     )
     assert r1.status_code == 201
     h1 = r1.json()["event_hash"]
@@ -115,6 +123,7 @@ def test_audit_events_hash_chain(client, token_write):
         data={"payload": {"n": 2}},
         content_type="application/json",
         HTTP_AUTHORIZATION=f"Bearer {token_write}",
+        HTTP_X_REQUEST_ID="audit-chain-2",
     )
     assert r2.status_code == 201
     data2 = r2.json()
@@ -130,6 +139,7 @@ def test_audit_events_list_returns_200(client, token_read_write, token_write):
         data={"payload": {"x": 1}},
         content_type="application/json",
         HTTP_AUTHORIZATION=f"Bearer {token_write}",
+        HTTP_X_REQUEST_ID="audit-list-1",
     )
     response = client.get(
         "/audit/events/",
@@ -150,6 +160,7 @@ def test_audit_events_detail_returns_200(client, token_read_write, token_write):
         data={"payload": {"detail": "ok"}},
         content_type="application/json",
         HTTP_AUTHORIZATION=f"Bearer {token_write}",
+        HTTP_X_REQUEST_ID="audit-detail-1",
     )
     assert r.status_code == 201
     eid = r.json()["id"]
@@ -169,6 +180,7 @@ def test_audit_events_detail_returns_200(client, token_read_write, token_write):
 def test_audit_event_append_only_no_update():
     """既存レコードの save（更新）は ValidationError。"""
     e = AuditEvent.objects.create(
+        request_id="audit-model-update",
         prev_hash="",
         event_hash="a" * 64,
         payload={"x": 1},
@@ -183,6 +195,7 @@ def test_audit_event_append_only_no_update():
 def test_audit_event_no_delete():
     """インスタンス delete は ValidationError。"""
     e = AuditEvent.objects.create(
+        request_id="audit-model-delete",
         prev_hash="",
         event_hash="b" * 64,
         payload={},

--- a/services/root/tests/test_service_jwt.py
+++ b/services/root/tests/test_service_jwt.py
@@ -5,6 +5,8 @@ Service JWT 認証の動作確認（Issue #4）。
 - 不正 scope は 403
 - 正しい JWT + scope で 200
 """
+import uuid
+
 import pytest
 from django.conf import settings
 from django.test import Client
@@ -45,6 +47,7 @@ def test_root_without_jwt_returns_401(client):
     """JWT なしでルートにアクセスすると 401。"""
     response = client.get("/")
     assert response.status_code == 401
+    uuid.UUID(response["X-Request-Id"])
     data = response.json()
     assert "detail" in data
     assert "JWT" in data["detail"] or "token" in data["detail"].lower()
@@ -52,14 +55,33 @@ def test_root_without_jwt_returns_401(client):
 
 def test_root_with_invalid_token_returns_401(client):
     """不正トークンで 401。"""
-    response = client.get("/", HTTP_AUTHORIZATION="Bearer invalid-token")
+    request_id = "invalid-token-request"
+    response = client.get(
+        "/",
+        HTTP_AUTHORIZATION="Bearer invalid-token",
+        HTTP_X_REQUEST_ID=request_id,
+    )
     assert response.status_code == 401
+    assert response["X-Request-Id"] == request_id
 
 
 def test_root_with_valid_jwt_returns_200(client, valid_token):
     """有効な JWT でルートにアクセスすると 200。"""
+    request_id = "valid-token-request"
+    response = client.get(
+        "/",
+        HTTP_AUTHORIZATION=f"Bearer {valid_token}",
+        HTTP_X_REQUEST_ID=request_id,
+    )
+    assert response.status_code == 200
+    assert response["X-Request-Id"] == request_id
+
+
+def test_root_without_request_id_generates_uuid(client, valid_token):
+    """X-Request-Id 未指定時は UUID が生成される。"""
     response = client.get("/", HTTP_AUTHORIZATION=f"Bearer {valid_token}")
     assert response.status_code == 200
+    uuid.UUID(response["X-Request-Id"])
 
 
 def test_internal_example_without_scope_returns_403(client, token_without_scope):

--- a/shared/tracing/__init__.py
+++ b/shared/tracing/__init__.py
@@ -1,0 +1,17 @@
+from .middleware import (
+    REQUEST_ID_HEADER,
+    REQUEST_ID_MAX_LENGTH,
+    RequestIdLogFilter,
+    RequestTracingMiddleware,
+    get_current_request_id,
+    normalize_request_id,
+)
+
+__all__ = [
+    "REQUEST_ID_HEADER",
+    "REQUEST_ID_MAX_LENGTH",
+    "RequestIdLogFilter",
+    "RequestTracingMiddleware",
+    "get_current_request_id",
+    "normalize_request_id",
+]

--- a/shared/tracing/middleware.py
+++ b/shared/tracing/middleware.py
@@ -1,0 +1,61 @@
+"""
+Request tracing support for service-to-service calls.
+"""
+import uuid
+from contextvars import ContextVar
+
+
+REQUEST_ID_HEADER = "X-Request-Id"
+REQUEST_ID_META_KEY = "HTTP_X_REQUEST_ID"
+REQUEST_ID_MAX_LENGTH = 64
+
+_current_request_id = ContextVar("current_request_id", default=None)
+
+
+def normalize_request_id(value):
+    """Return a usable request id, or an empty string when the header is invalid."""
+    if value is None:
+        return ""
+    request_id = str(value).strip()
+    if not request_id or len(request_id) > REQUEST_ID_MAX_LENGTH:
+        return ""
+    if "\n" in request_id or "\r" in request_id:
+        return ""
+    return request_id
+
+
+def get_current_request_id(default=None):
+    return _current_request_id.get() or default
+
+
+class RequestTracingMiddleware:
+    """
+    Attach a request id to each request and response.
+
+    Incoming X-Request-Id is reused when valid. Otherwise a UUID is generated.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request_id = normalize_request_id(request.META.get(REQUEST_ID_META_KEY))
+        if not request_id:
+            request_id = str(uuid.uuid4())
+
+        request.request_id = request_id
+        token = _current_request_id.set(request_id)
+        try:
+            response = self.get_response(request)
+            response[REQUEST_ID_HEADER] = request_id
+            return response
+        finally:
+            _current_request_id.reset(token)
+
+
+class RequestIdLogFilter:
+    """Add request_id to log records so formatters can include it."""
+
+    def filter(self, record):
+        record.request_id = get_current_request_id("-")
+        return True


### PR DESCRIPTION
## Summary
- Add shared request tracing middleware for `X-Request-Id` generation, request context storage, response propagation, and log filtering.
- Wire tracing/logging into Root, Legislative, Judiciary, and Executive services.
- Persist `request_id` on Root audit events and propagate the header through internal HTTP calls from Legislative and Executive services.

## Issue
Closes #11

## Validation
- `PYTHONPATH=services/root poetry run pytest services/root/tests`
- `PYTHONPATH=services/legislative poetry run pytest --ds=legislative.settings services/legislative/tests/test_laws_proposals_api.py`
- `PYTHONPATH=services/executive poetry run pytest --ds=executive.settings services/executive/tests/test_exec_proposals_api.py`
- `PYTHONPATH=services/root poetry run python services/root/manage.py makemigrations --check --dry-run`
- `PYTHONPATH=services/root poetry run python services/root/manage.py check`
- `PYTHONPATH=services/legislative poetry run python services/legislative/manage.py check`
- `PYTHONPATH=services/judiciary poetry run python services/judiciary/manage.py check`
- `PYTHONPATH=services/executive poetry run python services/executive/manage.py check`